### PR TITLE
use OAEP

### DIFF
--- a/SmartCredentials_aOS/build.gradle
+++ b/SmartCredentials_aOS/build.gradle
@@ -40,7 +40,7 @@ allprojects {
         androidMinSdkVersion = 21
         androidMinSdkVersionEid = 24
         androidVersionCode = 5
-        androidVersionName = "6.6.0"
+        androidVersionName = "6.6.1"
         androidNdkVersion = "23.1.7779620"
 
         androidXAppcompat = "1.5.1"

--- a/SmartCredentials_aOS/security/src/main/java/de/telekom/smartcredentials/security/encryption/RSACipherManager.java
+++ b/SmartCredentials_aOS/security/src/main/java/de/telekom/smartcredentials/security/encryption/RSACipherManager.java
@@ -49,7 +49,7 @@ import static de.telekom.smartcredentials.security.utils.Constants.KEY_ALGORITHM
 public class RSACipherManager extends CipherManager {
 
     private static final String CIPHER_ALGORITHM_MODE_ECB = "ECB";
-    private static final String CIPHER_ALGORITHM_PADDING_PKCS1 = "PKCS1Padding";
+    private static final String CIPHER_ALGORITHM_PADDING_PKCS1 = "OAEPWithSHA-1AndMGF1Padding";
     private static final String CIPHER_ALGORITHM = Constants.KEY_ALGORITHM_RSA + "/"
             + CIPHER_ALGORITHM_MODE_ECB + "/" + CIPHER_ALGORITHM_PADDING_PKCS1;
     private static final String X500_NAME = "CN=Sample Name, O=Android Authority";


### PR DESCRIPTION
Cryptographic algorithms often use padding schemes to make the plaintext less predictable. The OAEP (Optimal Asymmetric Encryption Padding) scheme should be used with RSA encryption. Using an outdated padding scheme such as PKCS1, or no padding at all, can weaken the encryption by making it vulnerable to a padding oracle attack.